### PR TITLE
gitignore config.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ model_path
 .cog
 __pycache__
 
+config.yaml
 models/**


### PR DESCRIPTION
After following the quickstart in the README, I had this leftover file in my checkout. Probably best to ignore it.