### PR TITLE
Ensure that tokenizer's `chat_template` is used by default

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -46,13 +46,23 @@ class Predictor(BasePredictor):
             self.config = PredictorConfig(
                 **config
             )  # pylint: disable=attribute-defined-outside-init
+
         else:
-            print(
-                "No predictor_config.json file found in weights, using default prompt template"
+            self.config = PredictorConfig()
+
+        print("Predictor Configuration:")
+        for key, value in self.config._asdict().items():
+            print(f"{key}: {value}")
+
+        if not weights:
+            raise ValueError(
+                "Weights must be provided. "
+                "Set COG_WEIGHTS environment variable to "
+                "a URL to a tarball containing the model artifacts "
+                "or a path to the model artifacts."
             )
-            self.config = PredictorConfig(
-                prompt_template=PROMPT_TEMPLATE
-            )  # pylint: disable=attribute-defined-outside-init
+
+        weights = await download_and_extract_tarball(str(weights))
 
         engine_args = AsyncEngineArgs(
             dtype="auto",
@@ -63,6 +73,7 @@ class Predictor(BasePredictor):
         self.engine = AsyncLLMEngine.from_engine_args(
             engine_args
         )  # pylint: disable=attribute-defined-outside-init
+
         self.tokenizer = (
             self.engine.engine.tokenizer.tokenizer
             if hasattr(self.engine.engine.tokenizer, "tokenizer")
@@ -70,7 +81,20 @@ class Predictor(BasePredictor):
         )  # pylint: disable=attribute-defined-outside-init
 
         if self.config.prompt_template:
+            print(
+                f"Using prompt template from `predictor_config.json`: {self.config.prompt_template}"
+            )
             self.tokenizer.chat_template = self.config.prompt_template
+
+        elif self.tokenizer.chat_template:
+            print(
+                f"Using prompt template from `tokenizer`: {self.tokenizer.chat_template}"
+            )
+        else:
+            print(
+                f"No prompt template specified in `predictor_config.json` or `tokenizer`, defaulting to: {PROMPT_TEMPLATE}"
+            )
+            self.tokenizer.chat_template = PROMPT_TEMPLATE
 
     async def predict(  # pylint: disable=invalid-overridden-method, arguments-differ
         self,

--- a/predict.py
+++ b/predict.py
@@ -54,16 +54,6 @@ class Predictor(BasePredictor):
         for key, value in self.config._asdict().items():
             print(f"{key}: {value}")
 
-        if not weights:
-            raise ValueError(
-                "Weights must be provided. "
-                "Set COG_WEIGHTS environment variable to "
-                "a URL to a tarball containing the model artifacts "
-                "or a path to the model artifacts."
-            )
-
-        weights = await download_and_extract_tarball(str(weights))
-
         engine_args = AsyncEngineArgs(
             dtype="auto",
             tensor_parallel_size=max(torch.cuda.device_count(), 1),


### PR DESCRIPTION
This PR modifies the way we set `prompt_template`. Currently, if a `chat_template` is set on `tokenizer`, we override it. This is not always desired (#14). Accordingly, in this PR, the `prompt_template` is determined like:

```
if self.config.prompt_template:
    self.tokenizer.chat_template = self.config.prompt_template
elif self.tokenizer.chat_template:
   pass
else:
   # Use a default template ("<s>{prompt", in our case)
   self.tokenizer.chat_template = PROMPT_TEMPLATE
```

This allows users to override the tokenizer chat template by setting a prompt template in `predictor_config.json`. However, in cases where there is not an override, we'll now use the correct template if it is stored in the tokenizer.