### PR TITLE
Feature: Allow COG_WEIGHTS to point to local path

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -12,7 +12,7 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.sampling_params import SamplingParams
 
 import prompt_templates
-from utils import download_and_extract_tarball
+from utils import resolve_model_path
 
 PROMPT_TEMPLATE = prompt_templates.COMPLETION  # Change this for instruct models
 
@@ -35,7 +35,7 @@ class Predictor(BasePredictor):
                 "or a path to the weights file."
             )
 
-        weights = await download_and_extract_tarball(str(weights))
+        weights = await resolve_model_path(str(weights))
 
         if os.path.exists(os.path.join(weights, "predictor_config.json")):
             print("Loading predictor_config.json")

--- a/utils.py
+++ b/utils.py
@@ -1,26 +1,52 @@
 import os
 import subprocess
 import time
+import warnings
 
 
-async def download_and_extract_tarball(
-    url: str,
-) -> str:
+async def resolve_model_path(url_or_local_path: str) -> str:
     """
-    Downloads a tarball from `url` and extracts to `dirname` if `dirname` does not exist.
+    Resolves the model path, downloading if necessary.
 
     Args:
-        url (str): URL to the tarball
+        url_or_local_path (str): URL to the tarball or local path to a directory containing the model artifacts.
 
     Returns:
-        path (str): Path to the directory where the tarball was extracted
+        str: Path to the directory containing the model artifacts.
     """
+    if "://" in url_or_local_path:
+        return await download_tarball(url_or_local_path)
+    else:
+        if not os.path.exists(url_or_local_path):
+            raise ValueError(
+                f"E1000: The provided local path '{url_or_local_path}' does not exist."
+            )
+        if not os.listdir(url_or_local_path):
+            raise ValueError(
+                f"E1000: The provided local path '{url_or_local_path}' is empty."
+            )
 
+        warnings.warn(
+            "Using local model artifacts for development is okay, but not optimal for production. "
+            "To minimize boot time, store model assets externally on Replicate."
+        )
+        return url_or_local_path
+
+
+async def download_tarball(url: str) -> str:
+    """
+    Downloads a tarball from a URL and extracts it.
+
+    Args:
+        url (str): URL to the tarball.
+
+    Returns:
+        str: Path to the directory where the tarball was extracted.
+    """
     filename = os.path.splitext(os.path.basename(url))[0]
     path = os.path.join(os.getcwd(), "models", filename)
-
     if os.path.exists(path) and os.listdir(path):
-        print(f"Files already present in the `{path}`, nothing will be downloaded.")
+        print(f"Files already present in `{path}`.")
         return path
 
     print(f"Downloading model assets to {path}...")
@@ -28,5 +54,4 @@ async def download_and_extract_tarball(
     command = ["pget", url, path, "-x"]
     subprocess.check_call(command, close_fds=True)
     print(f"Downloaded model assets in {time.time() - start_time:.2f}s")
-
     return path


### PR DESCRIPTION
Currently, COG_WEIGHTS cannot be set to a local path. However, this is sometimes a convenient workflow. This PR relaxes the requirement that COG_WEIGHTS is a URL. 

This allows users to set `COG_WEIGHTS` to a local path. Under this PR, local paths will be validated and simply returned. 

I also added a warning that informs users that they shouldn't push models with local weights.