### PR TITLE
Make build depend on previous steps

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -37,9 +37,9 @@ jobs:
         run: pip install -r requirements-dev.txt
       - name: Run unit tests
         run: pytest tests/unit
-
   build-and-push:
     name: Build and push
+    needs: [lint, unit-tests]
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
The current build-and-push workflow doesn't depend on lint and unit tests, but it should.