### PR TITLE
Only build and push on dispatch

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -2,9 +2,6 @@ name: CI
 
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 # Ensure only one workflow instance runs at a time. For branches other than the
@@ -43,7 +40,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@v3
       - name: Install Cog


### PR DESCRIPTION
This commit restricts build-and-push workflow executions to dispatch triggers. Builds are slow and expensive and that makes it tempting to bloat PRs. It would be better to have surgical PRs that pass tests and then trigger a build.