### PR TITLE
Manually install cog 0.10.0-alpha20 in build ci

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -58,6 +58,12 @@ jobs:
         with:
           token: ${{ secrets.REPLICATE_API_TOKEN }}
 
+      - name: Install Cog
+        run: |
+          COG_URL="https://github.com/replicate/cog/releases/download/v0.10.0-alpha20/cog_$(uname -s)_$(uname -m)"
+          sudo curl -o /usr/local/bin/cog -L "$COG_URL"
+          sudo chmod +x /usr/local/bin/cog
+
       - name: Push to Replicate
         run: cog push r8.im/replicate/vllm
           


### PR DESCRIPTION
The `replicate/setup-cog@v2` step installs a version of cog that is not compatible with cog async. Attempting to fix this with a manual install.