### PR TITLE
Make test prediction at end of setup

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -6,6 +6,7 @@ from typing import Optional, Dict
 from uuid import uuid4
 from dataclasses import dataclass, field
 from pprint import pprint
+import inspect
 
 import jinja2
 import torch  # pylint: disable=import-error
@@ -158,17 +159,28 @@ class Predictor(BasePredictor):
                 f"Using prompt template from `predictor_config.json`: {self.config.prompt_template}"
             )
             self.tokenizer.chat_template = self.config.prompt_template
+            self.prompt_template = None
 
         elif self.tokenizer.chat_template:
             print(
                 f"Using prompt template from `tokenizer`: {self.tokenizer.chat_template}"
             )
+            self.prompt_template = None
         else:
             print(
                 "No prompt template specified in `predictor_config.json` or "
                 f"`tokenizer`, defaulting to: {PROMPT_TEMPLATE}"
             )
-            self.tokenizer.chat_template = PROMPT_TEMPLATE
+            self.tokenizer.chat_template = None
+            self.prompt_template = PROMPT_TEMPLATE
+
+        self._testing = True
+        generator = self.predict(
+            **dict(self._defaults, **{"max_tokens": 3, "prompt": "hi"})
+        )
+        test_output = "".join([tok async for tok in generator])
+        print("Test prediction output:", test_output)
+        self._testing = False
 
     async def predict(  # pylint: disable=invalid-overridden-method, arguments-differ, too-many-arguments, too-many-locals
         self,
@@ -218,7 +230,8 @@ class Predictor(BasePredictor):
     ) -> ConcatenateIterator[str]:
         start = time.time()
 
-        if prompt_template:
+        if prompt_template or self.prompt_template:
+            prompt_template = prompt_template or self.prompt_template
             prompt = format_prompt(
                 prompt=prompt,
                 prompt_template=prompt_template,
@@ -332,3 +345,9 @@ class Predictor(BasePredictor):
             config = PredictorConfig()
         pprint(config)
         return config
+
+    _defaults = {
+        key: param.default.default
+        for key, param in inspect.signature(predict).parameters.items()
+        if hasattr(param.default, "default")
+    }


### PR DESCRIPTION
In general, it is possible for Predict to be broken, even if setup completes. While it would be preferable to never push a model with a broken Predict, it's still useful to mitigate this risk by failing models with broken Predict during setup.

This commit makes a short test prediction at the end of setup. If the prediction fails, the model is broken and will fail setup.

It also fixes a bug where default prompt templates were not correctly used to format prompts.