### PR TITLE
Add seed to inputs

### DIFF
--- a/tests/end_to_end/local/test_predict.py
+++ b/tests/end_to_end/local/test_predict.py
@@ -19,9 +19,8 @@ def test_predict():
 
     try:
 
-        with open(config_filename, "w") as temp_config:
+        with open(config_filename, "w", encoding="utf-8") as temp_config:
             json.dump(predictor_config, temp_config, indent=4)
-
         weights_url = "https://weights.replicate.delivery/default/internal-testing/EleutherAI/pythia-70m/model.tar"  # pylint: disable=line-too-long
 
         result = subprocess.run(


### PR DESCRIPTION
This commit adds a `seed` input. During predict, if seed is None, a random seed is sampled. The seed is then passed to vLLM sampling args. Finally, we log the seed value so that users can produce outputs deterministically.